### PR TITLE
List of changes:

### DIFF
--- a/NtupleInit.f
+++ b/NtupleInit.f
@@ -286,6 +286,8 @@ c	endif
 	  NtupleTag(m) = 'vyi'	! 58
 	  m = m+1
 	  NtupleTag(m) = 'vzi'	! 59
+	  m = m+1
+	  NtupleTag(m) = 'ebeam'! 60
 	endif
 
 !	else		!used to be the if (doing_phsp) option.

--- a/event.f
+++ b/event.f
@@ -122,8 +122,8 @@
 	type(event_main):: main
 	type(event):: vertex, orig
 
-	real*8 vxi,vyi,vzi
-	common /reconz/ vxi,vyi,vzi
+	real*8 vxi,vyi,vzi,vEin
+	common /reconz/ vxi,vyi,vzi,vEin
 
 	real*8 nsig_max
 	parameter(nsig_max=3.0e0)      !max #/sigma for gaussian ran #s.
@@ -193,6 +193,9 @@ C modified 5/15/06 for poinct
 	endif
 	vertex%Ein = Ebeam + (grnd()-0.5)*dEbeam +
      >		main%target%Coulomb - main%target%Eloss(1)
+
+	! corrected beam energy
+	vEin = vertex%Ein
 
 ! ... deterimine known variation in Ein from Ebeam_vertex_ave and in
 ! ... Ee due to Coulomb energy to compare limits to generated event by event.

--- a/results_write.f
+++ b/results_write.f
@@ -10,8 +10,8 @@
 	type(event_main):: main
 	type(event):: vertex, orig, recon
 
-	real*8 vxi,vyi,vzi
-	common /reconz/ vxi,vyi,vzi
+	real*8 vxi,vyi,vzi,vEin
+	common /reconz/ vxi,vyi,vzi,vEin
 
 !local (e,e'p) calculations:
 	real*8 poftheta		!p as calculated from theta, assuming elastic.
@@ -243,6 +243,7 @@ c	  ntu(11) = vertex%p%xptar			!mr
 	  ntu(57) = vxi
 	  ntu(58) = vyi
 	  ntu(59) = vzi
+	  ntu(60) = vEin
 	endif
 
 c	call HFN(NtupleID,ntu)

--- a/run_simc_tree
+++ b/run_simc_tree
@@ -1,12 +1,9 @@
-./simc << endofinput > runout/$1.out
+./simc << endofinput &> runout/$1.out
 $1
 endofinput
 cd util/root_tree
-./make_root_tree << endofinput
+./make_root_tree << endofinput &>> ../../runout/$1.out
 $1
 endofinput
 cd ../..
 rm worksim/$1.bin
-
-
-


### PR DESCRIPTION
1. Modified `run_simc_tree` script to redirect all the error messages to runout/*.out files in order to keep the terminal clean.
2. Added output ROOT tree branch to carry energy of the incident e- at the vertex (i.e. smeared Ebeam corrected for various losses in the target).