### PR TITLE
Set SIMC with GMn and GEn targets

### DIFF
--- a/dbase.f
+++ b/dbase.f
@@ -429,7 +429,7 @@ C DJG:
 	    targ%angle = 0.0
 	    write(6,*) 'Forcing target angle to zero for cryotarget.'
 	  endif
-	  if (targ%can.ne.1 .and. targ%can.ne.2) stop 'bad targ.can value'
+	  if (targ%can.gt.5) stop 'bad targ.can value'
 	endif
 	if(sin(targ%angle) .gt. 0.85) then
 	  write(6,*) 'BAD targ.angle (0 is perp. to beam, +ve is rotated towards SOS)'
@@ -652,7 +652,7 @@ C DJG:
 
 
 ! ... initialize limits on generation, cuts, edges
-
+	write(*,*) ' call limits init'
 	call limits_init(H)
 
 ! ... some announcements

--- a/init.f
+++ b/init.f
@@ -216,7 +216,6 @@ c	  targ%Coulomb%max = targ%Coulomb_constant * 3.0
 	SPedge%p%yptar%max = SPedge%p%yptar%max + slop%MC%p%yptar%used
 	SPedge%p%xptar%min = SPedge%p%xptar%min - slop%MC%p%xptar%used
 	SPedge%p%xptar%max = SPedge%p%xptar%max + slop%MC%p%xptar%used
-
 ! Compute TRUE edges -- distortions in the target come into play
 
 	edge%e%E%min = (1.+SPedge%e%delta%min/100.)*spec%e%P +
@@ -267,7 +266,6 @@ c	  targ%Coulomb%max = targ%Coulomb_constant * 3.0
 	edge%p%yptar%max = SPedge%p%yptar%max + targ%musc_max(3)
 	edge%p%xptar%min = SPedge%p%xptar%min - targ%musc_max(3)
 	edge%p%xptar%max = SPedge%p%xptar%max + targ%musc_max(3)
-
 ! Edges on values of Em and Pm BEFORE reconstruction% Need to apply slop to
 ! take into account all transformations from ORIGINAL TRUE values to
 ! RECONSTRUCTED TRUE values --> that includes: (a) reconstruction slop on
@@ -777,21 +775,30 @@ c	exponentiate = use_expon
      >		* gamma(one+lambda(3)) / gamma(one+g_int)
 
 ! External constants
-
 	do i = 1, 2
 	  c_ext(i) = bt(i)/e(i)**bt(i)/gamma(one+bt(i))
 	enddo
 	c_ext(3) = 0.0
 	g_ext = bt(1) + bt(2)
-	c_ext(0) = c_ext(1)*c_ext(2) * g_ext / bt(1)/bt(2)
-	c_ext(0) = c_ext(0)*gamma(one+bt(1))*gamma(one+bt(2))/gamma(one+g_ext)
+	if ( bt(2) .ne. 0) then
+            c_ext(0) = c_ext(1)*c_ext(2) * g_ext / bt(1)/bt(2)
+	     c_ext(0) = c_ext(0)*gamma(one+bt(1))*gamma(one+bt(2))/gamma(one+g_ext)
+	else 
+             c_ext(0) = c_ext(1)
+	endif
 
 ! Internal + external constants
 
+	if ( bt(2) .ne. 0) then
 	do i = 1, 2
 	  c(i) = c_int(i) * c_ext(i) * g(i)/lambda(i)/bt(i)
      >		* gamma(one+lambda(i))*gamma(one+bt(i))/gamma(one+g(i))
 	enddo
+        else
+	  c(1) = c_int(1) * c_ext(1) * g(1)/lambda(1)/bt(1)
+     >		* gamma(one+lambda(1))*gamma(one+bt(1))/gamma(one+g(1))
+	  c(2) = c_int(2)
+	   endif
 	c(3) = c_int(3)
 
 ! Finally, constant for combined tails

--- a/simc.f
+++ b/simc.f
@@ -1367,7 +1367,7 @@ c	enddo
 
 ! ... multiple scattering
 
-	if (mc_smear) then
+	if (mc_smear .and. main%target%teff(3) .gt.0) then
 	  beta = orig%p%p/orig%p%E
 	  call target_musc(orig%p%p, beta, main%target%teff(3), dangles)
 	else
@@ -1583,7 +1583,7 @@ C	  recon%p%delta = (recon%p%P-spec%p%P)/spec%p%P*100.
 
 ! ... multiple scattering
 
-	if (mc_smear) then
+	if (mc_smear.and. main%target%teff(2) .gt.0) then
 	  call target_musc(orig%e%p, beta_electron, main%target%teff(2), dangles)
 	else
 	  dangles(1)=0.0

--- a/target.inc
+++ b/target.inc
@@ -1,7 +1,19 @@
 ! TARGET.INC
 
 ! Constants
-
+! properties of Corning Glass 180
+	real*8		rho_Glass, Z_Glass, A_Glass, X0_Glass, X0_cm_Glass
+	parameter	(rho_Glass = 2.76)  !Z/A = 0.4829
+	parameter	(Z_Glass = 14.)  ! this gives the right ionization potential
+	parameter	(A_Glass = Z_Glass/.4829)
+	parameter	(X0_Glass = 19.425)
+	parameter	(X0_cm_Glass = X0_Glass/rho_Glass)
+	real*8		rho_Be, Z_Be, A_Be, X0_Be, X0_cm_Be
+	parameter	(rho_Be = 1.85)
+	parameter	(Z_Be = 4.)
+	parameter	(A_Be = 9.0121831)
+	parameter	(X0_Be = 65.19)
+	parameter	(X0_cm_Be = X0_Be/rho_Be)
 	real*8		rho_Al, Z_Al, A_Al, X0_Al, X0_cm_Al
 	parameter	(rho_Al = 2.70)
 	parameter	(Z_Al = 13.)


### PR DESCRIPTION
Will only calculate external brem and multiple scatteringeffects for incoming electron beam

GMN target info
https://logbooks.jlab.org/files/2022/03/3987411/TGT-RPT-22-002.pdf LH2 was bottom loop 1
entrance = 0.132mm exit = 0.152   side wall =  0.136
LD2 was bottom loop 3
entrance = 0.119 exit = 0.155   side wall = 0.137

Only the entrance thickness is important for the incoming electron

1) GMN LH2 target  targ%can=3
2) GMN LD2 target   targ%can=4
3) GEN glass target  targ%can=5

The energy loss and radiation length are calculated for the incoming beam electron (narm=1), Edit the code target.f and target.inc
For the scattering electron(narm=2) and hadron (narm=3) the target.f will return Eloss=0 and radlen = 0 for targ%can >=3.
Incoming electron beam
-------------------------
1) GMN LH2 is aluminum entrance window  and LH2 to the ztarget interaction point 
2) GMN LD2 is aluminum entrance window and LD2 to the ztarget interaction point
3) GEN is berylium beam line window, air and glass entrance window + 3He to ztarget interaction point.
   Use the input file radlen for the 3He target
   Berylium is 0.01 inches thick. Air is 16.2cm and glass is 150x10-4 cm thick 
   Got properties Corning Glass 180  Z/A = 0.4829 used Z= 14 which gives ionization potential listed in the properties list.
https://galileo.phys.virginia.edu/research/groups/spinphysics/glass_properties.html


Modified dbase.f to allow targ%can up to 5.


Modified simc.f so not do to mc_smear if radlen = 0 to scattered electron and hardon.


Modified init.f to initialize using only the incoming electron.